### PR TITLE
178 minor improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,7 +71,8 @@
         "concepts": "cpp",
         "netfwd": "cpp",
         "numbers": "cpp",
-        "shared_mutex": "cpp"
+        "shared_mutex": "cpp",
+        "configuration.h": "c"
     },
     "cmake.configureOnOpen": false
 }

--- a/inc/configuration.h
+++ b/inc/configuration.h
@@ -32,7 +32,9 @@
 #define USB_CDC_ENABLED true
 
 // Adjust the CPU clock frequency here (133 MHz is maximum documented stable frequency)
-#define CPU_FREQ_KHZ 133000
+#ifndef CPU_FREQ_KHZ
+    #define CPU_FREQ_KHZ 133000
+#endif
 
 // The minimum amount of time we check for an open line before taking control of it
 // Set to 0 to completely disable this check

--- a/inc/configuration.h
+++ b/inc/configuration.h
@@ -31,6 +31,9 @@
 // true to enable USB CDC (serial) interface to directly control the maple bus
 #define USB_CDC_ENABLED true
 
+// true to enable USB MSC (mass storage) interface to read/write VMU files
+#define USB_MSC_ENABLED true
+
 // Adjust the CPU clock frequency here (133 MHz is maximum documented stable frequency)
 #ifndef CPU_FREQ_KHZ
     #define CPU_FREQ_KHZ 133000

--- a/src/hal/Usb/Client/tusb_config.h
+++ b/src/hal/Usb/Client/tusb_config.h
@@ -79,7 +79,7 @@ extern "C" {
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC             1 // CDC always defined, even when not used
-#define CFG_TUD_MSC             1
+#define CFG_TUD_MSC             1 // MSC always defined, even when not used
 #define CFG_TUD_HID             MAX_NUMBER_OF_USB_GAMEPADS
 #define CFG_TUD_MIDI            0
 #define CFG_TUD_VENDOR          0

--- a/src/hal/Usb/Client/usb_descriptors.c
+++ b/src/hal/Usb/Client/usb_descriptors.c
@@ -177,13 +177,19 @@ uint8_t const *tud_hid_descriptor_report_cb(uint8_t instance)
 // Configuration Descriptor
 //--------------------------------------------------------------------+
 
-#if USB_CDC_ENABLED
-    #define DEBUG_CONFIG_LEN TUD_CDC_DESC_LEN
+#if USB_MSC_ENABLED
+    #define MSC_DESC_LEN TUD_MSC_DESC_LEN
 #else
-    #define DEBUG_CONFIG_LEN 0
+    #define MSC_DESC_LEN 0
 #endif
 
-#define GET_CONFIG_LEN(numGamepads) (TUD_CONFIG_DESC_LEN + (numGamepads * TUD_HID_DESC_LEN) + DEBUG_CONFIG_LEN + TUD_MSC_DESC_LEN)
+#if USB_CDC_ENABLED
+    #define CDC_DESC_LEN TUD_CDC_DESC_LEN
+#else
+    #define CDC_DESC_LEN 0
+#endif
+
+#define GET_CONFIG_LEN(numGamepads) (TUD_CONFIG_DESC_LEN + (numGamepads * TUD_HID_DESC_LEN) + CDC_DESC_LEN + MSC_DESC_LEN)
 
 // Endpoint definitions (must all be unique)
 #define EPIN_GAMEPAD1   (0x84)
@@ -240,7 +246,9 @@ uint8_t desc_configuration[] =
     // * Storage Device Descriptor                                             *
     // *************************************************************************
 
+#if USB_MSC_ENABLED
     MSC_DESCRIPTOR(MAX_NUMBER_OF_USB_GAMEPADS),
+#endif
 
     // *************************************************************************
     // * Communication Device Descriptor  (for debug messaging)                *
@@ -275,11 +283,13 @@ uint8_t const *tud_descriptor_configuration_cb(uint8_t index) {
         offset += sizeof(gpConfig);
     }
 
+#if USB_MSC_ENABLED
     uint8_t mscConfig[] = {
         MSC_DESCRIPTOR(numberOfGamepads)
     };
     memcpy(&desc_configuration[offset], mscConfig, sizeof(mscConfig));
     offset += sizeof(mscConfig);
+#endif
 
 #if USB_CDC_ENABLED
     uint8_t cdcConfig[] = {

--- a/src/hal/Usb/Client/usb_descriptors.h
+++ b/src/hal/Usb/Client/usb_descriptors.h
@@ -38,9 +38,23 @@
 // For mass storage device
 #define ITF_NUM_MSC (4)
 
+#if USB_MSC_ENABLED
+    #define NUM_ITF_MSC (1)
+#else
+    #define NUM_ITF_MSC (0)
+#endif
+
+// For serial device
 #define ITF_NUM_CDC (5)
-#define ITF_NUM_CDC_DATA (6)
-#define ITF_COUNT(numGamepads) (numGamepads + 3)
+#define ITF_NUM_CDC_DATA (6) // Implied, not directly used
+
+#if USB_CDC_ENABLED
+    #define NUM_ITF_CDC (2)
+#else
+    #define NUM_ITF_CDC (0)
+#endif
+
+#define ITF_COUNT(numGamepads) (numGamepads + NUM_ITF_CDC + NUM_ITF_MSC)
 
 //! Minumum analog value defined in USB HID descriptors
 static const int8_t MIN_ANALOG_VALUE = -127;

--- a/src/main/Host/CMakeLists.txt
+++ b/src/main/Host/CMakeLists.txt
@@ -4,6 +4,11 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 
 file(GLOB HOST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/host*.c*")
 
+if (${PICO_BOARD} STREQUAL "pico2")
+  # Increase the CPU frequency to 150MHz for the pico2 board
+  add_definitions(-DCPU_FREQ_KHZ=150000)
+endif()
+
 #
 # host-4p
 #


### PR DESCRIPTION
- Increase clock to 150 MHz when pico2 used (doesn't have any noticeable change, but may as well reduce any latency as much as possible)
- Fix `USB_CDC_ENABLED` when false
- Add `USB_MSC_ENABLED` to optionally disable mass storage