### PR TITLE
197 if outgoing vendor buffer is not empty on disconnect this causes issues on next connection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_definitions(-D_DEBUG)
 endif()
 
+# Longer pico boot delay
+add_compile_definitions(PICO_XOSC_STARTUP_DELAY_MULTIPLIER=8)
+
 if(NOT ENABLE_UNIT_TEST)
   # Have pico_sdk_import.cmake use the local SDK if it was pulled down; otherwise, use path at
   # PICO_SDK_PATH environment variable as specified within pico_sdk_import.cmake

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cd DreamPicoPort
 ```bash
 git submodule update --recursive --init
 ```
-Hint: if you have issues building, the easiest way to correct any submodule synchronization issue is to delete the `ext/pico-sdk` directory (ex: `rm -rf ext/pico-sdk`), and then re-run the above submodule update command.
+Hint: if you have issues building, the easiest way to correct any submodule synchronization issue is to delete the `ext/pico-sdk` directory (ex: `rm -rf ext/pico-sdk`), restore the directory `git restore ext/pico-sdk`, and then re-run the above submodule update command.
 
 5. (optional) Build and run tests - this runs core lib unit tests locally
 ```bash

--- a/docs/webusb/application.js
+++ b/docs/webusb/application.js
@@ -77,6 +77,8 @@
     let testsStressButton = document.querySelector('#tests-stress');
     let testsStatusDisplay = document.querySelector('#tests-status');
 
+    let lastReceivedReleaseTag = null;
+
     const CMD_OK = 0x0A; // Command success
     const CMD_ATTENTION = 0x0B; // Command success, but attention is needed
     const CMD_FAIL = 0x0F; // Command failed - data was parsed but execution failed
@@ -432,11 +434,12 @@
       }
 
       // Check for latest version
+      versionUpdateDisplay.innerHTML = "";
       getLatestReleaseTag().then(tagName => {
         if (tagName == null) {
           console.error("Failed to retrieve latest release tag name from github");
         } else {
-          console.log(`tag name: ${tagName}`);
+          console.log(`last release tag name: ${tagName}`);
           const versionStr = tagName.startsWith('v') ? tagName.slice(1) : tagName;
           const parts = versionStr.split('.');
           if (parts.length !== 3) {
@@ -787,6 +790,10 @@
     async function getLatestReleaseTag() {
       const url = "https://api.github.com/repos/OrangeFox86/DreamPicoPort/releases/latest"
 
+      if (lastReceivedReleaseTag != null) {
+        return lastReceivedReleaseTag;
+      }
+
       try {
         const response = await fetch(url, {
           headers: {
@@ -801,6 +808,7 @@
 
         const data = await response.json();
         // The 'tag_name' field contains the release tag (e.g., "v1.0.0")
+        lastReceivedReleaseTag = data.tag_name;
         return data.tag_name;
 
       } catch (error) {

--- a/docs/webusb/application.js
+++ b/docs/webusb/application.js
@@ -46,10 +46,10 @@
     let vmu2DRadio = document.querySelector('#vmu2-d-radio');
     let readVmuButton = document.querySelector('#read-vmu');
     let writeVmuButton = document.querySelector('#write-vmu');
-    let vmuProgressContainer = document.querySelector('#vmu-progress-container');
-    let vmuProgress = document.querySelector('#vmu-progress')
-    let vmuProgressText = document.querySelector('#vmu-progress-label')
-    let vmuMemoryCancelButton = document.querySelector('#vmu-memory-cancel')
+    let progressContainer = document.querySelector('#progress-container');
+    let progressBar = document.querySelector('#progress')
+    let progressText = document.querySelector('#progress-label')
+    let cancelButton = document.querySelector('#cancel-button')
     let gpioAText = document.querySelector('#gpio-a');
     let gpioBText = document.querySelector('#gpio-b');
     let gpioCText = document.querySelector('#gpio-c');
@@ -173,6 +173,7 @@
       if (receiveSm) {
         if (typeof receiveSm.done === 'function') {
           receiveSm.done(reason);
+          enableAllControls();
         } else {
           receiveSm.defaultDone(reason);
         }
@@ -216,6 +217,7 @@
     // State machine function: Called when connection phase has been successfully completed
     function connectionComplete() {
       if (receiveSm) {
+        disableAllControls(true);
         receiveSm.start();
         resetSmTimeout();
       }
@@ -290,14 +292,18 @@
         tabcontent[i].style.pointerEvents = 'auto';
         tabcontent[i].style.opacity = 1.0;
       }
+      selectButton.disabled = false;
     }
 
     // Disable all controls in within the form besides the Select Device button
-    function disableAllControls() {
+    function disableAllControls(disableSelectButton = false) {
       let tabcontent = document.getElementsByClassName("tabcontent");
       for (let i = 0; i < tabcontent.length; i++) {
         tabcontent[i].style.pointerEvents = 'none';
         tabcontent[i].style.opacity = 0.7;
+      }
+      if (disableSelectButton) {
+        selectButton.disabled = true;
       }
     }
 
@@ -471,9 +477,9 @@
 
     // Resets the progress bar on the VMU Memory tab
     function resetProgressBar() {
-      vmuProgress.value = 0;
-      vmuProgressContainer.style.display = 'none';
-      vmuProgressText.textContent = '0%';
+      progressBar.value = 0;
+      progressContainer.style.display = 'none';
+      progressText.textContent = '0%';
     }
 
     // Converts a controller index [0,3] to the Maple Bus host address
@@ -1018,10 +1024,10 @@
       }
 
       start() {
-        vmuProgressContainer.style.display = 'block';
-        vmuProgressContainer.style.visibility = 'visible';
-        vmuProgress.value = 0;
-        vmuProgressText.textContent = '0%';
+        progressContainer.style.display = 'block';
+        progressContainer.style.visibility = 'visible';
+        progressBar.value = 0;
+        progressText.textContent = '0%';
         this.startTime = Date.now();
         this.sendCurrentBlock();
       }
@@ -1043,8 +1049,8 @@
 
           // Update progress
           const progress = (this.currentBlock / 256) * 100;
-          vmuProgress.value = progress;
-          vmuProgressText.textContent = Math.round(progress) + '%';
+          progressBar.value = progress;
+          progressText.textContent = Math.round(progress) + '%';
 
           if (this.currentBlock < 256) {
             // Read next block
@@ -1148,10 +1154,10 @@
       }
 
       start() {
-        vmuProgressContainer.style.display = 'block';
-        vmuProgressContainer.style.visibility = 'visible';
-        vmuProgress.value = 0;
-        vmuProgressText.textContent = '0%';
+        progressContainer.style.display = 'block';
+        progressContainer.style.visibility = 'visible';
+        progressBar.value = 0;
+        progressText.textContent = '0%';
         this.startTime = Date.now();
         this.writeCurrentPhase();
       };
@@ -1186,8 +1192,8 @@
           // Update progress
           this.retries = 0;
           const progress = (this.currentBlock / WriteVmuStateMachine.TOTAL_BLOCKS) * 100;
-          vmuProgress.value = progress;
-          vmuProgressText.textContent = Math.round(progress) + '%';
+          progressBar.value = progress;
+          progressText.textContent = Math.round(progress) + '%';
 
           if (this.currentPhase > 3)
           {
@@ -1981,7 +1987,7 @@
     });
 
     // VMU Memory Cancel Button - click handler
-    vmuMemoryCancelButton.addEventListener('click', function () {
+    cancelButton.addEventListener('click', function () {
       cancelSm(SM_DONE_REASON_CANCELED_USER);
     });
 

--- a/docs/webusb/index.html
+++ b/docs/webusb/index.html
@@ -220,14 +220,6 @@
         <div style="text-align: center;">
             <button id="read-vmu" class="button black">Read Selected VMU</button>&nbsp;&nbsp;&nbsp;
             <button id="write-vmu" class="button black">Write Selected VMU</button>
-            <br>
-            <div id="vmu-progress-container" style="width: 60%; margin: 20px auto; display: none;">
-              <progress id="vmu-progress" value="0" max="100" style="width: 100%; height: 24px;"></progress>
-              <span id="vmu-progress-label" style="margin-left: 12px;">0%</span>
-              <br>
-              <br>
-              <button id="vmu-memory-cancel" class="button black">Cancel</button>
-            </div>
         </div>
       </div>
 
@@ -405,6 +397,14 @@
         </div>
       </div>
 
+      <br>
+      <div id="progress-container" style="text-align: center; width: 60%; margin: 20px auto; display: none;">
+        <progress id="progress" value="0" max="100" style="width: 100%; height: 24px;"></progress>
+        <span id="progress-label" style="margin-left: 12px;">0%</span>
+        <br>
+        <br>
+        <button id="cancel-button" class="button black">Cancel</button>
+      </div>
       <br>
       <div id="offline-hint"></div>
     </div>

--- a/docs/webusb/serial.js
+++ b/docs/webusb/serial.js
@@ -35,6 +35,7 @@ var serial = {};
       // 2048 is about twice as much as actually required
       this.device_.transferIn(this.endpointIn, 2048).then(result => {
         if (result.data && result.data.byteLength > 0) {
+          // console.info(`[${Array.from(new Uint8Array(result.data.buffer)).map(b => '0x' + b.toString(16).padStart(2, '0')).join(', ')}]`);
           this.onReceive(result.data);
         }
         readLoop();

--- a/src/hal/Usb/Client/usb_descriptors.c
+++ b/src/hal/Usb/Client/usb_descriptors.c
@@ -32,6 +32,7 @@
 #include "configuration.h"
 #include "dpp_version.h"
 #include <string.h>
+#include <stdio.h>
 
 #include <hal/Usb/client_usb_interface.h>
 

--- a/src/hal/Usb/Client/webusb.cpp
+++ b/src/hal/Usb/Client/webusb.cpp
@@ -26,6 +26,7 @@
 #include "tusb_config.h"
 #include "usb_descriptors.h"
 #include "hal/System/LockGuard.hpp"
+#include "utils.h"
 
 #include <string>
 #include <cstdint>
@@ -67,12 +68,14 @@ public:
 
     WebUsbInterface(uint8_t itf) : mItf(itf) {}
 
-    void syncReset()
+    uint32_t syncReset()
     {
         LockGuard lock(*webusb_mutex);
+        uint32_t s = (mRcvIdx > 0 ? mRcvIdx : 0) + mBuffer.size();
         reset();
         mIncomingBuffer.clear();
         mIncomingBuffer.shrink_to_fit();
+        return s;
     }
 
     void reset()
@@ -241,6 +244,64 @@ public:
         }
     }
 
+    static void sendPkt(
+        const uint8_t itfIdx,
+        const std::string& address,
+        const uint8_t cmd,
+        const std::list<std::pair<const void*, std::uint16_t>>& payloadList
+    )
+    {
+        std::uint16_t payloadLen = 0;
+        for (const auto& it : payloadList)
+        {
+            payloadLen += it.second;
+        }
+
+        const std::uint16_t pktSize = address.size() + kSizeCommand + payloadLen + kSizeCrc;
+        const std::uint16_t invPktSize = pktSize ^ 0xFFFF;
+        std::uint8_t headerSize = static_cast<std::uint8_t>(kSizeMagic + kSizeSize + address.size() + kSizeCommand);
+        std::uint8_t header[headerSize];
+        memcpy(&header[0], k_webusb_magic_value, kSizeMagic);
+        uint16ToBytes(&header[kSizeMagic], pktSize);
+        uint16ToBytes(&header[kSizeMagic + sizeof(pktSize)], invPktSize);
+        memcpy(&header[kSizeMagic + kSizeSize], address.data(), address.size());
+        header[kSizeMagic + kSizeSize + address.size()] = cmd;
+
+        // Calculate CRC over message address, command, and payload (excluding CRC itself)
+        uint16_t crc = computeCrc16(&header[kSizeMagic + kSizeSize], headerSize - (kSizeMagic + kSizeSize));
+        for (const auto& it : payloadList)
+        {
+            crc = computeCrc16(crc, it.first, it.second);
+        }
+        std::uint8_t crcBuffer[kSizeCrc];
+        uint16ToBytes(crcBuffer, crc);
+
+        {
+            LockGuard lock(*webusb_mutex);
+
+            if (vendorWrite(itfIdx, header, headerSize) != headerSize)
+            {
+                // Failed to write
+                return;
+            }
+
+            for (const auto& it : payloadList)
+            {
+                if (vendorWrite(itfIdx, it.first, it.second) != it.second)
+                {
+                    // Failed to write
+                    return;
+                }
+            }
+
+            if (vendorWrite(itfIdx, crcBuffer, sizeof(crcBuffer), true) != sizeof(crcBuffer))
+            {
+                // Failed to write
+                return;
+            }
+        }
+    }
+
 private:
     void processPkt(const std::string& address, const uint8_t cmd, const uint8_t* payload, uint16_t payloadLen)
     {
@@ -301,64 +362,6 @@ private:
         }
 
         return totalWritten;
-    }
-
-    static void sendPkt(
-        const uint8_t itfIdx,
-        const std::string& address,
-        const uint8_t cmd,
-        const std::list<std::pair<const void*, std::uint16_t>>& payloadList
-    )
-    {
-        std::uint16_t payloadLen = 0;
-        for (const auto& it : payloadList)
-        {
-            payloadLen += it.second;
-        }
-
-        const std::uint16_t pktSize = address.size() + kSizeCommand + payloadLen + kSizeCrc;
-        const std::uint16_t invPktSize = pktSize ^ 0xFFFF;
-        std::uint8_t headerSize = static_cast<std::uint8_t>(kSizeMagic + kSizeSize + address.size() + kSizeCommand);
-        std::uint8_t header[headerSize];
-        memcpy(&header[0], k_webusb_magic_value, kSizeMagic);
-        uint16ToBytes(&header[kSizeMagic], pktSize);
-        uint16ToBytes(&header[kSizeMagic + sizeof(pktSize)], invPktSize);
-        memcpy(&header[kSizeMagic + kSizeSize], address.data(), address.size());
-        header[kSizeMagic + kSizeSize + address.size()] = cmd;
-
-        // Calculate CRC over message address, command, and payload (excluding CRC itself)
-        uint16_t crc = computeCrc16(&header[kSizeMagic + kSizeSize], headerSize - (kSizeMagic + kSizeSize));
-        for (const auto& it : payloadList)
-        {
-            crc = computeCrc16(crc, it.first, it.second);
-        }
-        std::uint8_t crcBuffer[kSizeCrc];
-        uint16ToBytes(crcBuffer, crc);
-
-        {
-            LockGuard lock(*webusb_mutex);
-
-            if (vendorWrite(itfIdx, header, headerSize) != headerSize)
-            {
-                // Failed to write
-                return;
-            }
-
-            for (const auto& it : payloadList)
-            {
-                if (vendorWrite(itfIdx, it.first, it.second) != it.second)
-                {
-                    // Failed to write
-                    return;
-                }
-            }
-
-            if (vendorWrite(itfIdx, crcBuffer, sizeof(crcBuffer), true) != sizeof(crcBuffer))
-            {
-                // Failed to write
-                return;
-            }
-        }
     }
 
     static std::uint16_t bytesToUint16(const void* payload)
@@ -466,12 +469,20 @@ void webusb_connection_event(uint16_t interfaceNumber, uint16_t value)
 {
     // Called from USB core (core 0)
     uint8_t index = ITF_TO_WEBUSB_IDX(interfaceNumber);
-    if (index < webusb_interfaces.size() && value < 2)
+    if (index < webusb_interfaces.size() && value < 3)
     {
         // Connected or disconnected. In either case, reset state.
         webusb_interfaces[index].syncReset();
         // Also clear out the write buffer of anything waiting to be sent
         tud_vendor_n_write_clear(index);
+
+        if (value == 2)
+        {
+            // Send command 0 with max address
+            // This helps synchronize the beginning of the stream
+            std::string maxAddr(9, static_cast<char>(0xFF));
+            WebUsbInterface::sendPkt(index, maxAddr, 0, {});
+        }
     }
 }
 

--- a/src/hal/Usb/Client/webusb.cpp
+++ b/src/hal/Usb/Client/webusb.cpp
@@ -79,7 +79,7 @@ public:
         if (sendZeros && mLastSendSize >= 0)
         {
             // Write a bunch of zeros to ensure the last command gets pushed through if it got stuck
-            std::uint32_t writeSize = std::min(static_cast<uint32_t>(mLastSendSize), static_cast<uint32_t>(256U));
+            std::uint32_t writeSize = std::max(static_cast<uint32_t>(mLastSendSize), static_cast<uint32_t>(256U));
             mLastSendSize = -1;
             uint8_t buff[512] = {};
             while (writeSize > 0)

--- a/src/hal/Usb/Client/webusb.cpp
+++ b/src/hal/Usb/Client/webusb.cpp
@@ -35,6 +35,7 @@
 #include <array>
 #include <vector>
 #include <atomic>
+#include <algorithm>
 
 // Packet format (big endian order):
 // Magic Bytes [4] | Size [2] | Inverse Size [2] | Return Address [1-9] | Command [1] | Payload [0-N] | CRC [2]
@@ -68,13 +69,30 @@ public:
 
     WebUsbInterface(uint8_t itf) : mItf(itf) {}
 
-    uint32_t syncReset()
+    std::uint32_t init(bool connect)
     {
         LockGuard lock(*webusb_mutex);
-        uint32_t s = (mRcvIdx > 0 ? mRcvIdx : 0) + mBuffer.size();
+        std::uint32_t s = (mRcvIdx > 0 ? mRcvIdx : 0) + mBuffer.size();
         reset();
         mIncomingBuffer.clear();
         mIncomingBuffer.shrink_to_fit();
+
+        if (connect && mLastSendSize >= 0)
+        {
+            // Write a bunch of zeros to ensure the last command gets pushed through if it got stuck
+            std::uint32_t writeSize = std::min(static_cast<uint32_t>(mLastSendSize), static_cast<uint32_t>(256U));
+            mLastSendSize = -1;
+            uint8_t buff[512] = {};
+            while (writeSize > 0)
+            {
+                std::uint32_t s = std::min(static_cast<std::uint32_t>(sizeof(buff)), writeSize);
+                vendorWrite(mItf, buff, s, false);
+                writeSize -= s;
+            }
+            // to ensure crc gets processed too
+            vendorWrite(mItf, buff, 16, true);
+        }
+
         return s;
     }
 
@@ -244,8 +262,7 @@ public:
         }
     }
 
-    static void sendPkt(
-        const uint8_t itfIdx,
+    void sendPkt(
         const std::string& address,
         const uint8_t cmd,
         const std::list<std::pair<const void*, std::uint16_t>>& payloadList
@@ -279,7 +296,9 @@ public:
         {
             LockGuard lock(*webusb_mutex);
 
-            if (vendorWrite(itfIdx, header, headerSize) != headerSize)
+            mLastSendSize = pktSize;
+
+            if (vendorWrite(mItf, header, headerSize) != headerSize)
             {
                 // Failed to write
                 return;
@@ -287,14 +306,14 @@ public:
 
             for (const auto& it : payloadList)
             {
-                if (vendorWrite(itfIdx, it.first, it.second) != it.second)
+                if (vendorWrite(mItf, it.first, it.second) != it.second)
                 {
                     // Failed to write
                     return;
                 }
             }
 
-            if (vendorWrite(itfIdx, crcBuffer, sizeof(crcBuffer), true) != sizeof(crcBuffer))
+            if (vendorWrite(mItf, crcBuffer, sizeof(crcBuffer), true) != sizeof(crcBuffer))
             {
                 // Failed to write
                 return;
@@ -308,21 +327,20 @@ private:
         std::unordered_map<std::uint8_t, std::shared_ptr<WebUsbCommandHandler>>::iterator iter = mParsers.find(cmd);
         if (iter != mParsers.end() && iter->second)
         {
-            const uint8_t itf = mItf;
             iter->second->process(
                 payload,
                 payloadLen,
-                [itf = itf, address = address]
+                [this, address = address]
                 (std::uint8_t responseCmd, const std::list<std::pair<const void*, std::uint16_t>>& payloadList) -> void
                 {
-                    sendPkt(itf, address, responseCmd, payloadList);
+                    sendPkt(address, responseCmd, payloadList);
                 }
             );
         }
         else
         {
             // Unsupported command
-            sendPkt(mItf, address, kCmdBadCmd, {{&cmd, sizeof(cmd)}});
+            sendPkt(address, kCmdBadCmd, {{&cmd, sizeof(cmd)}});
         }
     }
 
@@ -449,6 +467,9 @@ private:
 
     //! Current receive buffer
     std::vector<std::uint8_t> mBuffer = std::vector<std::uint8_t>();
+
+    //! Last send packet size or -1 if none
+    std::int32_t mLastSendSize = -1;
 };
 
 // definition of mParsers
@@ -471,17 +492,16 @@ void webusb_connection_event(uint16_t interfaceNumber, uint16_t value)
     uint8_t index = ITF_TO_WEBUSB_IDX(interfaceNumber);
     if (index < webusb_interfaces.size() && value < 3)
     {
-        // Connected or disconnected. In either case, reset state.
-        webusb_interfaces[index].syncReset();
-        // Also clear out the write buffer of anything waiting to be sent
+        // Connected or disconnected. In either case, clear write buffer and reset state.
         tud_vendor_n_write_clear(index);
+        webusb_interfaces[index].init(value != 0);
 
         if (value == 2)
         {
             // Send command 0 with max address
             // This helps synchronize the beginning of the stream
             std::string maxAddr(9, static_cast<char>(0xFF));
-            WebUsbInterface::sendPkt(index, maxAddr, 0, {});
+            webusb_interfaces[index].sendPkt(maxAddr, 0, {});
         }
     }
 }

--- a/src/hal/Usb/Client/webusb.cpp
+++ b/src/hal/Usb/Client/webusb.cpp
@@ -69,15 +69,14 @@ public:
 
     WebUsbInterface(uint8_t itf) : mItf(itf) {}
 
-    std::uint32_t init(bool connect)
+    void externalReset(bool sendZeros = false, bool sendNullPkt = false)
     {
         LockGuard lock(*webusb_mutex);
-        std::uint32_t s = (mRcvIdx > 0 ? mRcvIdx : 0) + mBuffer.size();
         reset();
         mIncomingBuffer.clear();
         mIncomingBuffer.shrink_to_fit();
 
-        if (connect && mLastSendSize >= 0)
+        if (sendZeros && mLastSendSize >= 0)
         {
             // Write a bunch of zeros to ensure the last command gets pushed through if it got stuck
             std::uint32_t writeSize = std::min(static_cast<uint32_t>(mLastSendSize), static_cast<uint32_t>(256U));
@@ -93,7 +92,25 @@ public:
             vendorWrite(mItf, buff, 16, true);
         }
 
-        return s;
+        if (sendNullPkt)
+        {
+            // Send command 0 with max address
+            // This helps synchronize the beginning of the stream
+            std::string maxAddr(9, static_cast<char>(0xFF));
+            sendPkt(maxAddr, 0, {});
+        }
+    }
+
+    void connect(bool sendZeros, bool sendNullPkt)
+    {
+        externalReset(sendZeros, sendNullPkt);
+    }
+
+    void disconnect()
+    {
+        externalReset();
+        // Proper disconnection means last send size no longer needs to be tracked
+        mLastSendSize = -1;
     }
 
     void reset()
@@ -262,65 +279,6 @@ public:
         }
     }
 
-    void sendPkt(
-        const std::string& address,
-        const uint8_t cmd,
-        const std::list<std::pair<const void*, std::uint16_t>>& payloadList
-    )
-    {
-        std::uint16_t payloadLen = 0;
-        for (const auto& it : payloadList)
-        {
-            payloadLen += it.second;
-        }
-
-        const std::uint16_t pktSize = address.size() + kSizeCommand + payloadLen + kSizeCrc;
-        const std::uint16_t invPktSize = pktSize ^ 0xFFFF;
-        std::uint8_t headerSize = static_cast<std::uint8_t>(kSizeMagic + kSizeSize + address.size() + kSizeCommand);
-        std::uint8_t header[headerSize];
-        memcpy(&header[0], k_webusb_magic_value, kSizeMagic);
-        uint16ToBytes(&header[kSizeMagic], pktSize);
-        uint16ToBytes(&header[kSizeMagic + sizeof(pktSize)], invPktSize);
-        memcpy(&header[kSizeMagic + kSizeSize], address.data(), address.size());
-        header[kSizeMagic + kSizeSize + address.size()] = cmd;
-
-        // Calculate CRC over message address, command, and payload (excluding CRC itself)
-        uint16_t crc = computeCrc16(&header[kSizeMagic + kSizeSize], headerSize - (kSizeMagic + kSizeSize));
-        for (const auto& it : payloadList)
-        {
-            crc = computeCrc16(crc, it.first, it.second);
-        }
-        std::uint8_t crcBuffer[kSizeCrc];
-        uint16ToBytes(crcBuffer, crc);
-
-        {
-            LockGuard lock(*webusb_mutex);
-
-            mLastSendSize = pktSize;
-
-            if (vendorWrite(mItf, header, headerSize) != headerSize)
-            {
-                // Failed to write
-                return;
-            }
-
-            for (const auto& it : payloadList)
-            {
-                if (vendorWrite(mItf, it.first, it.second) != it.second)
-                {
-                    // Failed to write
-                    return;
-                }
-            }
-
-            if (vendorWrite(mItf, crcBuffer, sizeof(crcBuffer), true) != sizeof(crcBuffer))
-            {
-                // Failed to write
-                return;
-            }
-        }
-    }
-
 private:
     void processPkt(const std::string& address, const uint8_t cmd, const uint8_t* payload, uint16_t payloadLen)
     {
@@ -380,6 +338,65 @@ private:
         }
 
         return totalWritten;
+    }
+
+    void sendPkt(
+        const std::string& address,
+        const uint8_t cmd,
+        const std::list<std::pair<const void*, std::uint16_t>>& payloadList
+    )
+    {
+        std::uint16_t payloadLen = 0;
+        for (const auto& it : payloadList)
+        {
+            payloadLen += it.second;
+        }
+
+        const std::uint16_t pktSize = address.size() + kSizeCommand + payloadLen + kSizeCrc;
+        const std::uint16_t invPktSize = pktSize ^ 0xFFFF;
+        std::uint8_t headerSize = static_cast<std::uint8_t>(kSizeMagic + kSizeSize + address.size() + kSizeCommand);
+        std::uint8_t header[headerSize];
+        memcpy(&header[0], k_webusb_magic_value, kSizeMagic);
+        uint16ToBytes(&header[kSizeMagic], pktSize);
+        uint16ToBytes(&header[kSizeMagic + sizeof(pktSize)], invPktSize);
+        memcpy(&header[kSizeMagic + kSizeSize], address.data(), address.size());
+        header[kSizeMagic + kSizeSize + address.size()] = cmd;
+
+        // Calculate CRC over message address, command, and payload (excluding CRC itself)
+        uint16_t crc = computeCrc16(&header[kSizeMagic + kSizeSize], headerSize - (kSizeMagic + kSizeSize));
+        for (const auto& it : payloadList)
+        {
+            crc = computeCrc16(crc, it.first, it.second);
+        }
+        std::uint8_t crcBuffer[kSizeCrc];
+        uint16ToBytes(crcBuffer, crc);
+
+        {
+            LockGuard lock(*webusb_mutex);
+
+            mLastSendSize = pktSize;
+
+            if (vendorWrite(mItf, header, headerSize) != headerSize)
+            {
+                // Failed to write
+                return;
+            }
+
+            for (const auto& it : payloadList)
+            {
+                if (vendorWrite(mItf, it.first, it.second) != it.second)
+                {
+                    // Failed to write
+                    return;
+                }
+            }
+
+            if (vendorWrite(mItf, crcBuffer, sizeof(crcBuffer), true) != sizeof(crcBuffer))
+            {
+                // Failed to write
+                return;
+            }
+        }
     }
 
     static std::uint16_t bytesToUint16(const void* payload)
@@ -492,16 +509,16 @@ void webusb_connection_event(uint16_t interfaceNumber, uint16_t value)
     uint8_t index = ITF_TO_WEBUSB_IDX(interfaceNumber);
     if (index < webusb_interfaces.size() && value < 3)
     {
-        // Connected or disconnected. In either case, clear write buffer and reset state.
+        // Connected or disconnected. In either case, clear write buffer.
         tud_vendor_n_write_clear(index);
-        webusb_interfaces[index].init(value != 0);
 
-        if (value == 2)
+        if (value != 0)
         {
-            // Send command 0 with max address
-            // This helps synchronize the beginning of the stream
-            std::string maxAddr(9, static_cast<char>(0xFF));
-            webusb_interfaces[index].sendPkt(maxAddr, 0, {});
+            webusb_interfaces[index].connect(value == 1, value == 2);
+        }
+        else
+        {
+            webusb_interfaces[index].disconnect();
         }
     }
 }

--- a/src/hal/Usb/Client/webusb.cpp
+++ b/src/hal/Usb/Client/webusb.cpp
@@ -23,6 +23,7 @@
 
 #include "webusb.hpp"
 #include "tusb.h"
+#include "tusb_config.h"
 #include "usb_descriptors.h"
 #include "hal/System/LockGuard.hpp"
 
@@ -66,9 +67,12 @@ public:
 
     WebUsbInterface(uint8_t itf) : mItf(itf) {}
 
-    void signalReset()
+    void syncReset()
     {
-        mResetSignaled = true;
+        LockGuard lock(*webusb_mutex);
+        reset();
+        mIncomingBuffer.clear();
+        mIncomingBuffer.shrink_to_fit();
     }
 
     void reset()
@@ -110,14 +114,6 @@ public:
 
         {
             LockGuard lock(*webusb_mutex);
-
-            if (mResetSignaled.exchange(false))
-            {
-                reset();
-                mIncomingBuffer.clear();
-                mIncomingBuffer.shrink_to_fit();
-                return;
-            }
 
             if (!mIncomingBuffer.empty())
             {
@@ -436,9 +432,6 @@ private:
     //! The USB vendor interface number
     const uint8_t mItf;
 
-    //! Set when reset is signaled by connection event, to be processed later
-    std::atomic<bool> mResetSignaled = false;
-
     //! Current receive index
     std::int32_t mRcvIdx = -kSizeMagic;
 
@@ -476,7 +469,9 @@ void webusb_connection_event(uint16_t interfaceNumber, uint16_t value)
     if (index < webusb_interfaces.size() && value < 2)
     {
         // Connected or disconnected. In either case, reset state.
-        webusb_interfaces[index].signalReset();
+        webusb_interfaces[index].syncReset();
+        // Also clear out the write buffer of anything waiting to be sent
+        tud_vendor_n_write_clear(index);
     }
 }
 

--- a/src/hal/Usb/Client/webusb.cpp
+++ b/src/hal/Usb/Client/webusb.cpp
@@ -507,8 +507,14 @@ void webusb_connection_event(uint16_t interfaceNumber, uint16_t value)
 {
     // Called from USB core (core 0)
     uint8_t index = ITF_TO_WEBUSB_IDX(interfaceNumber);
-    if (index < webusb_interfaces.size() && value < 3)
+    if (index < webusb_interfaces.size() && value < 4)
     {
+        // value
+        // 0: Disconnect
+        // 1: Connect and send zeros to shift out last command
+        // 2: Connect and send null command
+        // 3: Connect only
+
         // Connected or disconnected. In either case, clear write buffer.
         tud_vendor_n_write_clear(index);
 

--- a/src/hostLib/webusb_parsers/SystemWebUsbCommandHandler.cpp
+++ b/src/hostLib/webusb_parsers/SystemWebUsbCommandHandler.cpp
@@ -1,0 +1,76 @@
+// MIT License
+//
+// Copyright (c) 2022-2025 James Smith of OrangeFox86
+// https://github.com/OrangeFox86/DreamcastControllerUsbPico
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "SystemWebUsbCommandHandler.hpp"
+
+#include <cstring>
+
+SystemWebUsbCommandHandler::SystemWebUsbCommandHandler(
+    SystemIdentification& identification
+) :
+    mIdentification(identification)
+{}
+
+void SystemWebUsbCommandHandler::process(
+    const std::uint8_t* payload,
+    std::uint16_t payloadLen,
+    const std::function<
+        void(std::uint8_t responseCmd, const std::list<std::pair<const void*, std::uint16_t>>& payloadList)
+    >& responseFn
+)
+{
+    const std::uint8_t* eol = payload + payloadLen;
+    const std::uint8_t* iter = payload;
+
+    if (iter >= eol)
+    {
+        responseFn(kResponseCmdInvalid, {});
+        return;
+    }
+
+    const char cmd = *iter++;
+    const std::size_t numPayload = (eol - iter);
+    switch(cmd)
+    {
+        // echo
+        case 'e':
+        {
+            responseFn(kResponseSuccess, {{iter, numPayload}});
+        }
+        break;
+
+        // serial
+        case 'S':
+        {
+            char buffer[mIdentification.getSerialSize() + 1] = {0};
+            mIdentification.getSerial(buffer, sizeof(buffer) - 1);
+            buffer[sizeof(buffer) - 1] = '\0';
+            responseFn(kResponseSuccess, {{buffer, strlen(buffer) + 1}});
+        }
+        return;
+
+        default:
+            responseFn(kResponseCmdInvalid, {{nullptr, 0}});
+            return;
+    }
+}

--- a/src/hostLib/webusb_parsers/SystemWebUsbCommandHandler.hpp
+++ b/src/hostLib/webusb_parsers/SystemWebUsbCommandHandler.hpp
@@ -1,0 +1,68 @@
+// MIT License
+//
+// Copyright (c) 2022-2025 James Smith of OrangeFox86
+// https://github.com/OrangeFox86/DreamcastControllerUsbPico
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "hal/Usb/WebUsbCommandHandler.hpp"
+#include "hal/System/SystemIdentification.hpp"
+#include "hal/System/MutexInterface.hpp"
+
+#include "PrioritizedTxScheduler.hpp"
+
+#include "PlayerData.hpp"
+#include "DreamcastMainNode.hpp"
+
+#include "MapleWebUsbCommandHandler.hpp"
+
+#include <memory>
+#include <list>
+#include <array>
+#include <functional>
+
+class SystemWebUsbCommandHandler : public WebUsbCommandHandler
+{
+public:
+    SystemWebUsbCommandHandler(
+        SystemIdentification& identification
+    );
+
+    virtual ~SystemWebUsbCommandHandler() = default;
+
+    //! Inherited from WebUsbCommandHandler
+    inline std::uint8_t getSupportedCommand() const override
+    {
+        return static_cast<std::uint8_t>('-');
+    }
+
+    //! Inherited from WebUsbCommandHandler
+    void process(
+        const std::uint8_t* payload,
+        std::uint16_t payloadLen,
+        const std::function<
+            void(std::uint8_t responseCmd, const std::list<std::pair<const void*, std::uint16_t>>& payloadList)
+        >& responseFn
+    ) override;
+
+private:
+    SystemIdentification& mIdentification;
+};

--- a/src/main/Host/CMakeLists.txt
+++ b/src/main/Host/CMakeLists.txt
@@ -20,6 +20,7 @@ pico_add_extra_outputs(host)
 target_link_libraries(host
   PRIVATE
     pico_multicore
+    hardware_exception
     hal-MapleBus
     hal-System
     hal-Usb-Client
@@ -50,6 +51,7 @@ if ("${PICO_BOARD}" STREQUAL "pico")
   target_link_libraries(zero_host
     PRIVATE
       pico_multicore
+      hardware_exception
       hal-MapleBus
       hal-System
       hal-Usb-Client

--- a/src/main/Host/host_main.cpp
+++ b/src/main/Host/host_main.cpp
@@ -28,8 +28,10 @@
 
 #include "pico/stdlib.h"
 #include "hardware/clocks.h"
+#include "hardware/exception.h"
 #include "pico/multicore.h"
 #include <hardware/watchdog.h>
+#include <atomic>
 
 #include "CriticalSectionMutex.hpp"
 #include "Mutex.hpp"
@@ -46,12 +48,50 @@ const uint32_t MAPLE_DIR_PINS[MAX_DEVICES] = {P1_DIR_PIN, P2_DIR_PIN, P3_DIR_PIN
 
 static std::map<uint8_t, DreamcastNodeData> dcNodes;
 
+// Shared watchdog heartbeat counter. Each core updates its bit to indicate liveness.
+static std::atomic<uint32_t> g_watchdog_heartbeat{0};
+
+// Watchdog configuration: timeout in milliseconds
+static constexpr uint32_t kSharedWatchdogTimeoutMs = 2000; // 2 seconds
+
+// Core heartbeat bit masks
+static constexpr uint32_t kMainCoreBit = 0x1u;
+static constexpr uint32_t kCore1Bit = 0x2u;
+static constexpr uint32_t kAllCoreBits = (kMainCoreBit | kCore1Bit);
+
+// Kick interval for hardware watchdog (microseconds)
+static constexpr uint32_t kWatchdogKickIntervalUs = 250000; // 250 ms
+
+// Helpers to set heartbeat bits from each core
+static inline void heartbeat_set_bit(uint32_t bit_mask)
+{
+    g_watchdog_heartbeat.fetch_or(bit_mask, std::memory_order_relaxed);
+}
+
+// Function both cores call to signal liveness
+static inline void shared_feed_watchdog(uint32_t core_bit)
+{
+    heartbeat_set_bit(core_bit);
+}
+
+// Exception handler for RP2040
+void __not_in_flash_func(exception_handler)()
+{
+    watchdog_enable(1, true);
+    while (true);
+}
+
 // Second Core Process
 // The second core is in charge of handling communication with Dreamcast peripherals
 void core1()
 {
+#ifndef _DEBUG
+    exception_set_exclusive_handler(HARDFAULT_EXCEPTION, exception_handler);
+#endif
+
     // Initialize TTY and WebUsb parsers
     std::unique_ptr<SerialStreamParser> ttyParser = make_parsers(dcNodes);
+    uint64_t lastWatchdogKick = time_us_64();
 
     while(true)
     {
@@ -67,6 +107,23 @@ void core1()
 
         // Process any waiting commands in the WebUSB parser
         webusb_process();
+
+        // Signal liveness to the shared watchdog (core1 uses kCore1Bit)
+        shared_feed_watchdog(kCore1Bit);
+
+        // Periodically kick the hardware watchdog if either core reported in interval
+        if ((time_us_64() - lastWatchdogKick) >= kWatchdogKickIntervalUs)
+        {
+            uint32_t hb = g_watchdog_heartbeat.load(std::memory_order_relaxed);
+            if ((hb & kAllCoreBits) != 0)
+            {
+                // Clear heartbeat for next interval and update watchdog
+                g_watchdog_heartbeat.store(0, std::memory_order_relaxed);
+                watchdog_update();
+            }
+
+            lastWatchdogKick = time_us_64();
+        }
     }
 }
 
@@ -75,6 +132,10 @@ void core1()
 int main()
 {
     set_sys_clock_khz(CPU_FREQ_KHZ, true);
+
+#ifndef _DEBUG
+    exception_set_exclusive_handler(HARDFAULT_EXCEPTION, exception_handler);
+#endif
 
     const bool mapleRebootDetected = (watchdog_hw->scratch[0] == WATCHDOG_MAPLE_AUTO_DETECT_MAGIC);
     const bool settingsRebootDetected = (watchdog_hw->scratch[0] == DppSettings::WATCHDOG_SETTINGS_UPDATED_MAGIC);
@@ -201,6 +262,13 @@ int main()
         currentDppSettings.simpleUsbLedGpio
     );
 
+    // Initialize and enable the hardware watchdog for shared use between cores.
+    // core1() will kick the hardware watchdog periodically if either core reports liveness.
+    watchdog_enable(kSharedWatchdogTimeoutMs, true);
+
+    // Clear any prior heartbeat state
+    g_watchdog_heartbeat.store(0, std::memory_order_relaxed);
+
     multicore_launch_core1(core1);
 
     if (allMapleAutoDetect && !rebootDetected && !dcNodes.empty())
@@ -241,6 +309,9 @@ int main()
 
             lastMapleDetectTime = time_us_32();
         }
+
+        // Signal main core liveness to shared watchdog
+        shared_feed_watchdog(kMainCoreBit);
 
         DppSettings::processSaveRequests(hwStopFn);
     }

--- a/src/main/Host/host_setup.cpp
+++ b/src/main/Host/host_setup.cpp
@@ -34,6 +34,7 @@
 #include "MapleWebUsbCommandHandler.hpp"
 #include "FlycastWebUsbCommandHandler.hpp"
 #include "SettingsWebUsbCommandHandler.hpp"
+#include "SystemWebUsbCommandHandler.hpp"
 
 #include "PicoIdentification.hpp"
 #include "CriticalSectionMutex.hpp"
@@ -114,6 +115,9 @@ std::unique_ptr<SerialStreamParser> make_parsers(
             dcNodes
         );
     webusb_add_parser(flycastWebUsbCommandParser);
+    std::shared_ptr<SystemWebUsbCommandHandler> systemWebUsbCommandHandler =
+        std::make_shared<SystemWebUsbCommandHandler>(picoIdentification);
+    webusb_add_parser(systemWebUsbCommandHandler);
     std::shared_ptr<SettingsWebUsbCommandHandler> settingsWebUsbCommandHandler = std::make_shared<SettingsWebUsbCommandHandler>();
     webusb_add_parser(settingsWebUsbCommandHandler);
 


### PR DESCRIPTION
- Clear outgoing buffer on connection/disconnection events
- Send a bunch of zeros to ensure any command stuck in the endpoint is shifted out on the host
- Added exception handler when not debug
- Added watchdog timeout
- Added a system WebUSB processor with an echo command - I think this could be used to send a random value and ensure the random value is echoed upon connection
- Connection value of 2 will send back a null command to potentially help with connection
- Added beep to basic test on webpage
- All webpage controls are disabled during any operation in order to prevent multiple clicks