### PR TITLE
Move diagnostics time retrieval to after diagnostics are retrieved

### DIFF
--- a/src/hostLib/webusb_parsers/SystemWebUsbCommandHandler.cpp
+++ b/src/hostLib/webusb_parsers/SystemWebUsbCommandHandler.cpp
@@ -91,9 +91,6 @@ void SystemWebUsbCommandHandler::process(
                 std::string response;
                 response.reserve(112);
 
-                const std::uint64_t now = mClock.getTimeUs();
-                appendIntToResponse(response, now);
-
                 // Keep reading status until last two reads are equal or total of 3 reads made
                 static constexpr uint32_t kMaxStatusReads = 3;
                 DreamcastMainNode::MapleStatus status = node.getMapleStatus();
@@ -114,6 +111,9 @@ void SystemWebUsbCommandHandler::process(
                         }
                     }
                 }
+
+                const std::uint64_t now = mClock.getTimeUs();
+                appendIntToResponse(response, now);
 
                 appendIntToResponse(response, static_cast<std::uint32_t>(synchronized));
 


### PR DESCRIPTION
This ensures all diagnostics timestamps will be in the past